### PR TITLE
Ez leka/readiness probe

### DIFF
--- a/.github/actions/deploy-kontain/action.yaml
+++ b/.github/actions/deploy-kontain/action.yaml
@@ -6,27 +6,7 @@ runs:
   steps:
     - name: Build kkm and kkm_test
       run: |
-        function wait_for_pod() {
-          set +e
-          # wait for pod to complete initialization
-          while [ -z "$status" ]
-          do 
-                  echo -n "."
-                  sleep 1s
-                  log=$(kubectl logs -l app=kontain-init -n kube-system 2>/dev/null)
-                  status="$(kubectl logs -l app=kontain-init -n kube-system 2>/dev/null | grep 'kontain-init completed')"
-          done
-        }
-        export -f wait_for_pod
 
         ./kontain-kustomize.sh --deploy-location=./kontain-deploy
 
-        timeout 1m bash -c wait_for_pod
-        echo
-        kubectl logs -l app=kontain-init -n kube-system
-        status=$(kubectl get pods -n kube-system -l app=kontain-init -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')
-        echo "Pod status = $status"
-        if [ "$status" != "True" ]; then  
-          exit 1; 
-        fi
       shell: bash {0}

--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -203,7 +203,6 @@ jobs:
   test-gce:
     name: GCE Deployment
     runs-on: ubuntu-20.04
-    #needs: [test-aks]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -203,6 +203,7 @@ jobs:
   test-gce:
     name: GCE Deployment
     runs-on: ubuntu-20.04
+    #needs: [test-aks]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -219,7 +220,7 @@ jobs:
 
       - name: Make cluster
         run: |
-          ./helpers/gce-cluster.sh --project=gke-suport ci-deployment-test
+          ./helpers/gce-cluster.sh --project=gke-suport ci-deployment-test-gke
           echo "USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> $GITHUB_ENV
           echo "Make sure cluster up and running"
           gcloud container clusters list
@@ -230,7 +231,11 @@ jobs:
 
       - uses: ./.github/actions/test-app
 
+      - name: Setup tmate session
+        if: ${{ failure() || ( github.event_name == 'workflow_dispatch' && inputs.tmate_enabled ) }}
+        uses: mxschmitt/action-tmate@v3
+
       - name: Cleanup cluster
         if: ${{ always() }}
         run: |
-          ./helpers/gce-cluster.sh --cleanup ci-deployment-test
+          ./helpers/gce-cluster.sh --cleanup ci-deployment-test-gke

--- a/helpers/gce-cluster.sh
+++ b/helpers/gce-cluster.sh
@@ -97,11 +97,9 @@ main() {
 
     subnet_zone=$(echo "$region" | sed  's/\-[^-]*$//')
     #Tell GKE to create a single zone, single node cluster for us. 
-    gcloud container --project="${project_name}" clusters create "${cluster_name}" \
+    gcloud container clusters create "${cluster_name}" --project="${project_name}"  \
         --zone="${region}" --image-type="UBUNTU_CONTAINERD" --num-nodes=1 \
-        --enable-ip-alias \
-        --network="projects/${project_name}/global/networks/default" \
-        --subnetwork="projects/${project_name}/regions/${subnet_zone}/subnetworks/default"
+        --enable-ip-alias
 
     gcloud container clusters get-credentials "${cluster_name}" --region "${region}"        
 

--- a/helpers/minikube-cluster.sh
+++ b/helpers/minikube-cluster.sh
@@ -105,7 +105,7 @@ do_restart() {
         minikube start
     elif [ "$driver" = 'podman' ]; then
         do_cleanup
-        minikube start --container-runtime="$runtime" --driver="$driver" --wait=all --logtostderr=true  --wait-timeout=10m0s --force-systemd=true
+        minikube start --container-runtime="$runtime" --driver="$driver" --wait=all --logtostderr=true --force-systemd=true
     fi
 }
 

--- a/helpers/minikube-cluster.sh
+++ b/helpers/minikube-cluster.sh
@@ -75,7 +75,7 @@ create_cluster() {
         extra_options="--preload=false"
     fi
     
-    minikube start --container-runtime="$runtime" --driver="$driver" "$extra_options" --wait=all --logtostderr=true  -v=10 --wait-timeout=10m0s
+    minikube start --container-runtime="$runtime" --driver="$driver" "$extra_options" --wait=all --logtostderr=true --force-systemd=true --wait-timeout=10m0s
 
     status=$(minikube status -ojson |jq -r '.APIServer')
     while [ $status != 'Running' ]

--- a/helpers/minikube-cluster.sh
+++ b/helpers/minikube-cluster.sh
@@ -75,7 +75,7 @@ create_cluster() {
         extra_options="--preload=false"
     fi
     
-    minikube start --container-runtime="$runtime" --driver="$driver" "$extra_options" --wait=all --logtostderr=true  --wait-timeout=10m0s
+    minikube start --container-runtime="$runtime" --driver="$driver" "$extra_options" --wait=all --logtostderr=true  -v=10 --wait-timeout=10m0s
 
     status=$(minikube status -ojson |jq -r '.APIServer')
     while [ $status != 'Running' ]
@@ -105,7 +105,7 @@ do_restart() {
         minikube start
     elif [ "$driver" = 'podman' ]; then
         do_cleanup
-        minikube start --container-runtime="$runtime" --driver="$driver" --wait=all --logtostderr=true  --wait-timeout=10m0s
+        minikube start --container-runtime="$runtime" --driver="$driver" --wait=all --logtostderr=true  --wait-timeout=10m0s --force-systemd=true
     fi
 }
 

--- a/kontain-deploy/base/entry-point.yaml
+++ b/kontain-deploy/base/entry-point.yaml
@@ -72,7 +72,13 @@ data:
       -H "Accept: application/json" \
       -XPATCH -d '{"metadata":{"labels":{"sandbox":"kontain"}}}' \
       -H "Content-Type: application/merge-patch+json" \
-      ${APISERVER}/api/v1/nodes/${MY_NODE_NAME} > /dev/null
+      ${APISERVER}/api/v1/nodes/${MY_NODE_NAME} > out.json
+
+    if ! grep --quiet '"sandbox": "kontain"' out.json ; then 
+      echo "Node labeling failed. Make sure your kubernetes service account has sufficient permissions"
+      cat out.json
+      exit 1
+    fi
 
     echo "kontain-init completed"
     mkdir -p /opt/kontain/config

--- a/kontain-deploy/base/entry-point.yaml
+++ b/kontain-deploy/base/entry-point.yaml
@@ -48,5 +48,34 @@ data:
     # restore resolve.conf after completing chroot 
     cp ${ROOT_MOUNT_DIR}/etc/resolv.conf.orig ${ROOT_MOUNT_DIR}/etc/resolv.conf
 
+    # Now update node's label to make it available to kontain deployments
+
+    # Point to the internal API server hostname
+    APISERVER=https://kubernetes.default.svc
+
+    # Path to ServiceAccount token
+    SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
+
+    # Read this Pod's namespace
+    NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+
+    # Read the ServiceAccount bearer token
+    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+
+    # Reference the internal certificate authority (CA)
+    CACERT=${SERVICEACCOUNT}/ca.crt
+
+    # my node name
+    echo "MY NODE NAME = $MY_NODE_NAME"
+
+    curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -k -v \
+      -H "Accept: application/json" \
+      -XPATCH -d '{"metadata":{"labels":{"sandbox":"kontain"}}}' \
+      -H "Content-Type: application/merge-patch+json" \
+      ${APISERVER}/api/v1/nodes/${MY_NODE_NAME} > /dev/null
+
     echo "kontain-init completed"
+    mkdir -p /opt/kontain/config
+    touch /opt/kontain/config/complete
+
     sleep infinity

--- a/kontain-deploy/base/kontain-deploy.yaml
+++ b/kontain-deploy/base/kontain-deploy.yaml
@@ -34,6 +34,11 @@ spec:
         - image: centos:7 # ubuntu:18.04
           name: node-initializer
           command: ["/scripts/entrypoint.sh"]
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           envFrom:
             - configMapRef:
                 name: env-configmap
@@ -61,6 +66,16 @@ spec:
               subPath: pre-install.sh
             - name: entrypoint
               mountPath: /scripts
+          readinessProbe:
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 1
+            exec:
+              command:
+                - cat
+                - /opt/kontain/config/complete
       volumes:
         - name: root-mount
           hostPath:

--- a/kontain-deploy/base/kontain-deploy.yaml
+++ b/kontain-deploy/base/kontain-deploy.yaml
@@ -107,3 +107,4 @@ spec:
           configMap:
             name: pre-install
             defaultMode: 0744
+      serviceAccountName: kontain-serviceaccount

--- a/kontain-deploy/base/service-account.yaml
+++ b/kontain-deploy/base/service-account.yaml
@@ -11,25 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - service-account.yaml
-  - entry-point.yaml
-  - pre-install.yaml
-  - kontain-install-artifacts.yaml
-  - runtime-config.yaml
-  - runtime-restart.yaml
-  - runtime-class.yaml
-  - kontain-deploy.yaml
-  - kvm-kkm-install.yaml
-
-configMapGenerator:
-  - name: env-configmap
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kontain-serviceaccount
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kontain-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kontain-serviceaccount
     namespace: kube-system
-    envs:
-      - .env
-      - config.properties
-generatorOptions:
-  disableNameSuffixHash: true

--- a/kontain-kustomize.sh
+++ b/kontain-kustomize.sh
@@ -281,7 +281,7 @@ kubectl "$command" --dry-run="$strategy" -f "${kontain_yaml}"
 if [ "$strategy" == "none" ] && [ "$command" == "apply" ]; then 
     echo "waiting for kontain deamonset to be running"
      
-    kubectl wait --for=condition=Ready pods -n kube-system -l app=kontain-init
+    kubectl wait --for=condition=Ready pods -n kube-system -l app=kontain-init --timeout=120s
 
     eval ${post_process}
 fi

--- a/kontain-kustomize.sh
+++ b/kontain-kustomize.sh
@@ -281,7 +281,7 @@ kubectl "$command" --dry-run="$strategy" -f "${kontain_yaml}"
 if [ "$strategy" == "none" ] && [ "$command" == "apply" ]; then 
     echo "waiting for kontain deamonset to be running"
      
-    kubectl wait --for=condition=Ready pods -n kube-system -l app=kontain-init --timeout=30s
+    kubectl wait --for=condition=Ready pods -n kube-system -l app=kontain-init --timeout=120s
 
     eval ${post_process}
 fi

--- a/kontain-kustomize.sh
+++ b/kontain-kustomize.sh
@@ -281,7 +281,7 @@ kubectl "$command" --dry-run="$strategy" -f "${kontain_yaml}"
 if [ "$strategy" == "none" ] && [ "$command" == "apply" ]; then 
     echo "waiting for kontain deamonset to be running"
      
-    kubectl wait --for=condition=Ready pods -n kube-system -l app=kontain-init --timeout=120s
+    kubectl wait --for=condition=Ready pods -n kube-system -l app=kontain-init --timeout=30s
 
     eval ${post_process}
 fi

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -12,8 +12,10 @@ spec:
         kontain: test-app
     spec:
       runtimeClassName: kontain
+      nodeSelector:
+        sandbox: kontain
       containers:
-      - name: kontain-test-app
-        image: busybox:latest
-        command: [ "sleep", "infinity" ]
-        imagePullPolicy: IfNotPresent
+        - name: kontain-test-app
+          image: busybox:latest
+          command: ["sleep", "infinity"]
+          imagePullPolicy: IfNotPresent


### PR DESCRIPTION
1. Implemented readiness probe to make sure when pod says ready it has completed all installations, including KKM which takes a long time
2. Implemented daemonset to label node  it has run on as kontain ready. All kontain applications should have 2 things added 
runrimeClass and 
nodeSelector:
        sandbox: kontain
to ensure that they are assigned to the properly configured node because runtimeClass creation is cluster-wide 